### PR TITLE
fix: change material for ply and add vertex color

### DIFF
--- a/src/3dLoader/loadModel.ts
+++ b/src/3dLoader/loadModel.ts
@@ -1,4 +1,4 @@
-import { Box3, Vector3, Mesh, MeshPhongMaterial, MeshStandardMaterial, Object3D, ObjectLoader } from "three";
+import { Box3, Vector3, Mesh, MeshPhongMaterial, MeshBasicMaterial, Object3D, ObjectLoader } from "three";
 import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader";
 import { ColladaLoader } from "three/examples/jsm/loaders/ColladaLoader";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
@@ -100,7 +100,7 @@ function getLoader(filePath: string, fileType: string, isDraco: boolean, dracoDi
         loader: new PLYLoader(manager),
         getObject: (geometry: any) => { // geometry
           geometry.computeVertexNormals();
-          return new Mesh(geometry, new MeshStandardMaterial());
+          return new Mesh(geometry, new MeshBasicMaterial({ vertexColors: true }));
         },
       };
       break;


### PR DESCRIPTION
Change the Material for `PLY` model to `MeshBasicMaterial` according to the stack overflow post at issue [57](https://github.com/king2088/vue-3d-loader/issues/57). Since `PLY` object is made of vertex, set the `vertexColor` to true. 