### PR TITLE
perf: cancel sourcemap and modify onResize method name #38

### DIFF
--- a/src/3dLoader/vue3dLoader.vue
+++ b/src/3dLoader/vue3dLoader.vue
@@ -150,16 +150,16 @@ export default {
       type: String,
       default: "MeshStandardMaterial"
     },
-    enableAxesHelper: { 
-      type: Boolean, 
+    enableAxesHelper: {
+      type: Boolean,
       default: false
     },
-    axesHelperSize: { 
-      type: Number, 
+    axesHelperSize: {
+      type: Number,
       default: 100
     },
-    enableGridHelper: { 
-      type: Boolean, 
+    enableGridHelper: {
+      type: Boolean,
       default: false
     },
     minDistance: {
@@ -320,7 +320,7 @@ export default {
       }
       const el = this.$refs.container;
       // init canvas width and height
-      this.onResize();
+      this.resizeModel();
       const WEB_GL_OPTIONS = { antialias: true, alpha: true };
       const options = Object.assign(
         {},
@@ -353,7 +353,7 @@ export default {
       el.addEventListener("mouseup", this.onMouseUp, false);
       el.addEventListener("click", this.onClick, false);
       el.addEventListener("dblclick", this.onDblclick, false);
-      window.addEventListener("resize", this.onResize, false);
+      window.addEventListener("resize", this.resizeModel, false);
       // stats
       if (this.showFps) {
         this.stats = new Stats();
@@ -383,13 +383,13 @@ export default {
       el.removeEventListener("mouseup", this.onMouseUp, false);
       el.removeEventListener("click", this.onClick, false);
       el.removeEventListener("dblclick", this.onDblclick, false);
-      window.removeEventListener("resize", this.onResize, false);
+      window.removeEventListener("resize", this.resizeModel, false);
       this.object = null;
       if (this.scene) {
         this.scene.clear();
       }
     },
-    onResize() {
+    resizeModel() {
       if (!this.width || !this.height) {
         this.$nextTick(() => {
           let el = this.$refs.container;

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,5 +2,7 @@ const { defineConfig } = require('@vue/cli-service')
 
 module.exports = defineConfig({
   transpileDependencies: true,
-  outputDir: 'examples-demo'
+  outputDir: 'examples-demo',
+  productionSourceMap: false,
+  css: { extract: false }
 })


### PR DESCRIPTION
```js
productionSourceMap: false //取消生成sourceMap，减小包体积
css: { extract: false } // css 样式内置，文档里面好像没有引入样式的说明
```
在用 uni-app 创建的 H5 项目中 onResize 和页面生命周期 onResize 冲突导致调用方法报错 undefined，所以修改了方法名，对应的问题有 #2 和 #38