### PR TITLE
fix: 灯光属性处理时，类型是点光源，类型判断中使用了驼峰名，导致使用时用 type: PointLight 定义的光源无法生效

### DIFF
--- a/src/3dLoader/vue3dLoader.vue
+++ b/src/3dLoader/vue3dLoader.vue
@@ -555,7 +555,7 @@ function updateLights() {
         item.intensity === 0 ? item.intensity : item.intensity || 1;
       light = new AmbientLight(color, intensity);
     }
-    if (type === "point" || type === "pointLight") {
+    if (type === "point" || type === "pointlight") {
       const color =
         item.color === 0x000000 ? item.color : item.color || 0xffffff;
       const intensity =


### PR DESCRIPTION
![image](https://github.com/king2088/vue-3d-loader/assets/17044194/cd56e043-b9dc-4be6-98d5-7e14e239948d)
Pascal风格的类型名不能匹配